### PR TITLE
Realme XT

### DIFF
--- a/lighthouse.devices
+++ b/lighthouse.devices
@@ -1,3 +1,4 @@
 tulip
 violet
 X2
+RMX1921

--- a/official_devices.json
+++ b/official_devices.json
@@ -13,6 +13,19 @@
         ]
     },
     {
+        "name": "Realme XT",
+        "brand": "Realme",
+        "codename": "RMX1921",
+        "supported_versions": [
+          {
+            "version_code": "raft",
+            "version_name": "R",
+            "maintainer_name": "Deepak Jangir",
+            "maintainer_git_url": "https://github.com/Deepak5310"
+          }
+        ]
+    },
+    {
         "name": "Redmi Note 7 Pro",
         "brand": "Xiaomi",
         "codename": "violet",


### PR DESCRIPTION
Device and codename:- RMX1921

Device tree:- https://github.com/Deepak5310/device_realme_RMX1921

Kernel source:- https://github.com/Deepak5310/android_kernel_realme_sdm710

Vendor Source:- https://github.com/Deepak5310/vendor_realme_RMX1921

Current Linux subversion:

Reason for prebuilt kernel (if exists):- not exist

What doesn't work:-  Everything working

Selinux:- Enforcing

Safetynet status:- Pass without Magisk

Telegram username: hacked001

XDA Profile: Deepak5310